### PR TITLE
StdのIteratorの実装の変更に対応

### DIFF
--- a/lib/math/bigint.fix
+++ b/lib/math/bigint.fix
@@ -273,7 +273,7 @@ impl BigInt: ToBytes {
         let u8_len = u32_len * 4;
         let bytes = Array::fill(u8_len, 0_U8);
         let bytes = Iterator::range(0, u32_len).fold(
-            bytes, |bytes, i|
+            bytes, |i, bytes|
             bytes.set_u32_be(4 * (u32_len - 1 - i), a.@nat.@(i))    // big endian
         );
         bytes

--- a/lib/math/bignat.fix
+++ b/lib/math/bignat.fix
@@ -679,17 +679,17 @@ _to_string_hex = |a| (
 _to_string: Array U32 -> String;
 _to_string = |a| (
     let a = a._remove_last_zeros;
-    let output = _to_string_inner(a, Iterator::empty);
-    let output = if output.is_empty { output.push_front('0') } else { output };
+    let output = _to_string_inner(a, DynIterator::empty);
+    let output = if output.is_empty { output.push_front('0').to_dyn } else { output };
     output.to_array._unsafe_to_string
 );
 
-_to_string_inner: Array U32 -> Iterator U8 -> Iterator U8;
+_to_string_inner: Array U32 -> DynIterator U8 -> DynIterator U8;
 _to_string_inner = |a, output| (
     if a.get_size == 0 { output };
     if a.get_size == 1 && a.@(0) == 0_U32 { output };
     let (quo, rem) = _divmod_u32(a, 10_U32);
-    let output = output.push_front('0' + rem.to_U8);
+    let output = output.push_front('0' + rem.to_U8).to_dyn;
     _to_string_inner(quo, output)
 );
 

--- a/lib/math/polynomial.fix
+++ b/lib/math/polynomial.fix
@@ -183,12 +183,10 @@ impl [a: Ring] Polynomial a: Mul {
         let x_degree = x.get_degree;
         let y_degree = y.get_degree;
         let degree = x_degree + y_degree;
-        let iter = do {
-            pure $ (*Iterator::range(0, x_degree + 1), *Iterator::range(0, y_degree + 1))
-        };
+        let iter = Iterator::range(0, x_degree + 1).product(Iterator::range(0, y_degree + 1));
         let coeff = Array::fill(degree + 1, zero);
         let coeff = iter.fold(
-            coeff, |coeff, (ix, iy)|
+            coeff, |(ix, iy), coeff|
             coeff.mod(ix + iy, add(x.get(ix) * y.get(iy)))
         );
         Polynomial::make(coeff)
@@ -241,26 +239,26 @@ is_primitive = |f| (
 );
 
 // `generate(p,m)` generates polynomials of degree `m` or lower in GF(p).
-generate: I64 -> I64 -> Iterator (Polynomial (Modular I64));
+generate: I64 -> I64 -> DynIterator (Polynomial (Modular I64));
 generate = |p, m| (
     let inner = fix $ |inner, m| (
         if m < 0 {
-            pure $ Iterator::empty
+            pure $ DynIterator::empty
         };
         let coeff = *inner(m - 1);
         Iterator::range(0, p).map(|i|
-            coeff.push_front(modulo(i, p))
-        )
+            coeff.push_front(modulo(i, p)).to_dyn
+        ).to_dyn
     );
     inner(m).map(to_array >> polynomial)
 );
 
 // `generate_primitive_polynomials(p, m)` generates primitive polynomials of degree `m` in GF(p).
-generate_primitive_polynomials: I64 -> I64 -> Iterator (Polynomial (Modular I64));
+generate_primitive_polynomials: I64 -> I64 -> DynIterator (Polynomial (Modular I64));
 generate_primitive_polynomials = |p, m| (
     Polynomial::generate(p, m)
     .filter(|f| f.get_degree == m)
-    .filter(is_primitive)
+    .filter(is_primitive).to_dyn
 );
 
 // `f.subst(x)` substitutes the indeterminate of a polynomial with `x`.

--- a/lib/math/ring.fix
+++ b/lib/math/ring.fix
@@ -11,7 +11,7 @@ import Minilib.Math.Types;
 
 // `repeat_by_U64(op, x, a, n)` calculates `x.op(a).op(a)...` for `n` times.
 // `op` is an associative binary operation.
-// This function returns the same result as `Iterator::range(0, n).fold(x, |x, _| x.op(a))`,
+// This function returns the same result as `Iterator::range(0, n).fold(x, |_, x| x.op(a))`,
 // but faster.
 repeat_by_U64: (a -> a -> a) -> a -> a -> U64 -> a;
 repeat_by_U64 = |op, x, a, n| (

--- a/tests/math/bigint_test.fix
+++ b/tests/math/bigint_test.fix
@@ -283,8 +283,7 @@ test_perf: IO ();
 test_perf = (
     let or_abort = |res| (
         if res.is_err {
-            eval debug_eprintln("error: " + res.as_err);
-            undefined()
+            undefined("error: " + res.as_err)
         };
         res.as_ok
     );


### PR DESCRIPTION
StdのIteratorの実装の変更に対応しました。

[bigint_test.fix](https://github.com/pt9999/fixlang-minilib-math/compare/main...tttmmmyyyy:fixlang-minilib-math:main?expand=1#diff-bd866f00ac5913259a3b5cf6bed3c3eb4d97e05cb1fbe374194005d48c4e6ca8) でのundefinedの使い方でエラーが発生していたので修正しました。