### PR TITLE
fix: avoid ambiguity with Std::One in newer Fix

### DIFF
--- a/lib/math/types.fix
+++ b/lib/math/types.fix
@@ -5,11 +5,6 @@ module Minilib.Math.Types;
 // which has addition(`add`), subtraction(`sub`), additive inverse(`neg`), additive unit(`zero`).
 trait AdditiveGroup = Eq + Zero + Neg + Add + Sub;
 
-// A trait that represents a multiplicative unit.
-trait a: One {
-    one: a;
-}
-
 // A trait that represents a [ring](https://en.wikipedia.org/wiki/Ring_(mathematics)),
 // which has addition(`add`), subtraction(`sub`), additive inverse(`neg`), additive unit(`zero`),
 // multiplication(`mul`), multiplicative unit(`one`).
@@ -56,16 +51,4 @@ trait Ordered = Eq + LessThan + LessThanOrEq;
 
 // [Ordered field](https://en.wikipedia.org/wiki/Ordered_field)
 trait OrderedField = Field + LessThan + LessThanOrEq;
-
-impl I64: One {
-    one = 1;
-}
-
-impl F64: One {
-    one = 1.0;
-}
-
-impl F32: One {
-    one = 1.0_F32;
-}
 


### PR DESCRIPTION
Std が同じ形`One` トレイトを提供するようになったので、minilibのOneを削除しました。

バージョンの変更だけどうするかご判断をお願いしたいです。